### PR TITLE
Overcome raw.github.com ban in Spain

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Please make sure the project compiles before submitting it.
 Find below the information regarding our endpoints:
 
 -   *Base Endpoint:*
-	- "https://raw.githubusercontent.com/ocadotechnology/mobile-challenge/master"
+	- "https://my-json-server.typicode.com/ocadotechnology/mobile-challenge"
 
 -   *Product list:*
-	-   GET “/product/all.json”
+	-   GET “/products”
   ```
   {
   "clusters": [
@@ -58,7 +58,7 @@ Find below the information regarding our endpoints:
 ```
 
 -   Product detail:
-	-   GET “/product/{product_id}.json”
+	-   GET “/product/{product_id}”
 ```
 {
   "id": 240875011,

--- a/db.json
+++ b/db.json
@@ -1,0 +1,236 @@
+{ 
+  "products": 
+    {
+      "clusters": [
+        {
+          "tag": "Bananas",
+          "items": [
+            {
+              "id": 309396011,
+              "price": "1.45",
+              "title": "Ocado Organic Fairtrade Bananas",
+              "size": "6 per pack",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/309396011/images/image/0/240x240.jpg"
+            },
+            {
+              "id": 227255011,
+              "price": "4.45",
+              "title": "Ocado Fairtrade Ripen at Home Bananas",
+              "size": "5 per pack",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/227255011/images/image/0/240x240.jpg"
+            }
+          ]
+        },
+        {
+          "tag": "Sugar & Home Baking",
+          "items": [
+            {
+              "id": 386138011,
+              "price": "0.90",
+              "title": "Ocado Sunflower Seeds",
+              "size": "100g",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/386138011/images/image/0/240x240.jpg"
+            },
+            {
+              "id": 407680011,
+              "price": "0.60",
+              "title": "Ocado Self Raising Flour",
+              "size": "1.5kg",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/407680011/images/image/0/240x240.jpg"
+            },        
+            {
+              "id": 386132011,
+              "price": "2.00",
+              "title": "Ocado Prunes",
+              "size": "250g",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/386132011/images/image/0/240x240.jpg"
+            }
+          ]
+        },
+        {
+          "tag": "Cucumber",
+          "items": [
+            {
+              "id": 240875011,
+              "price": "0.64",
+              "title": "Ocado Cucumber",
+              "size": "1 per pack",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/240875011/images/image/0/240x240.jpg"
+            }
+          ]
+        },
+        {
+          "tag": "Naan Bread",
+          "items": [
+            {
+              "id": 91056011,
+              "price": "1.15",
+              "title": "Ocado Mini Garlic & Coriander Naan",
+              "size": "6 per pack",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/91056011/images/image/0/240x240.jpg"
+            },
+            {
+              "id": 91061011,
+              "price": "0.95",
+              "title": "Ocado Garlic & Coriander Naan",
+              "size": "2 per pack",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/91061011/images/image/0/240x240.jpg"
+            }
+          ]
+        },
+        {
+          "tag": "Leeks & Garlic",
+          "items": [
+            {
+              "id": 91500011,
+              "price": "1.35",
+              "title": "Ocado Baby Leeks",
+              "size": "110g",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/91500011/images/image/0/240x240.jpg"
+            },
+            {
+              "id": 65453011,
+              "price": "0.85",
+              "title": "Ocado Red Onions",
+              "size": "3 per pack",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/65453011/images/image/0/240x240.jpg"
+            },
+            {
+              "id": 65448011,
+              "price": "0.85",
+              "title": "Ocado Brown Onions",
+              "size": "3 per pack",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/65448011/images/image/0/240x240.jpg"
+            },        
+            {
+              "id": 299133011,
+              "price": "1.20",
+              "title": "Ocado Organic Garlic",
+              "size": "4 per pack",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/299133011/images/image/0/240x240.jpg"
+            },
+            {
+              "id": 81851011,
+              "price": "1.00",
+              "title": "Ocado Shallots",
+              "size": "400g",
+              "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/81851011/images/image/0/240x240.jpg"
+            }
+          ]
+        }
+      ]
+   },
+  "product" : [
+    {
+      "id": 91500011,
+      "price": "1.35",
+      "title": "Ocado Baby Leeks",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/91500011/images/image/0/360x360.jpg",
+      "description": "All the same small size these firm tightly layered leeks have a subtle onion flavour.",
+      "allergyInformation": "No allergens"
+    },
+    {
+      "id": 91061011,
+      "price": "0.95",
+      "title": "Ocado Garlic & Coriander Naan",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/91061011/images/image/0/360x360.jpg",
+      "description": "Ocado 2 Garlic and Coriander Naan Bread.",
+      "allergyInformation": "Cereals containing gluten. Wheat Flour, milk, soya flour"
+    },
+    {
+      "id": 91056011,
+      "price": "1.15",
+      "title": "Ocado Mini Garlic & Coriander Naan",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/91056011/images/image/0/360x360.jpg",
+      "description": "Ocado 6 mini garlic and coriander naan bread.",
+      "allergyInformation": "Wheat flour, milk, soya flour"
+    },
+    {
+      "id": 81851011,
+      "price": "1.00",
+      "title": "Ocado Shallots",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/81851011/images/image/0/360x360.jpg",
+      "description": "Our finely layered shallots have a bright flemish free skin and are milder and sweeter than onions",
+      "allergyInformation": "No allergens"
+    },{
+      "id": 91061011,
+      "price": "0.95",
+      "title": "Ocado Garlic & Coriander Naan",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/91061011/images/image/0/360x360.jpg",
+      "description": "Ocado 2 garlic and coriander naan bread",
+      "allergyInformation": "Cereals containing gluten"
+    },
+    {
+      "id": 65453011,
+      "price": "0.85",
+      "title": "Ocado Red Onions",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/65453011/images/image/0/360x360.jpg",
+      "description": "Our red onions have a deep red shiny skin and are firm to the touch.",
+      "allergyInformation": "No allergens"
+    },
+    {
+      "id": 65448011,
+      "price": "0.85",
+      "title": "Ocado Brown Onions",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/65448011/images/image/0/240x240.jpg",
+      "description": "These large onions have a firm feel and a bright brown outer skin.",
+      "allergyInformation": "No allergens"
+    },
+    {
+      "id": 407680011,
+      "price": "0.60",
+      "title": "Ocado Self Raising Flour",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/407680011/images/image/0/240x240.jpg",
+      "description": "Ocado british self raising flour. Ideal for cakes and scones",
+      "allergyInformation": "Contains wheat"
+    },
+    {
+      "id": 386138011,
+      "price": "0.90",
+      "title": "Ocado Sunflower Seeds",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/386138011/images/image/0/240x240.jpg",
+      "description": "Ocado Sunflower Seeds. Serving suggestion. Nutty and crunchy, perfect for salads, sprinkling and baking.",
+      "allergyInformation": "May contain traces of nuts and sesame seeds."
+    },
+    {
+      "id": 386132011,
+      "price": "2.00",
+      "title": "Ocado Prunes",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/386132011/images/image/0/360x360.jpg",
+      "description": "Ocado dried pitted prunes. They're perfect as a snack or for adding a deliciously decadent touch to salads, starters and desserts.",
+      "allergyInformation": "May contain traces of soya and gluten."
+    },   
+    {
+      "id": 309396011,
+      "price": "1.45",
+      "title": "Ocado Organic Fairtrade Bananas",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/309396011/images/image/0/360x360.jpg",
+      "description": "Organic. Suitable for vegetarians",
+      "allergyInformation": "May contain traces of Sesame Seeds"
+    },
+    {
+      "id": 299133011,
+      "price": "1.20",
+      "title": "Ocado Organic Garlic",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/299133011/images/image/0/360x360.jpg",
+      "description": "Our plump bulb are firm the white flaky dry outer skin that the best garlic has.",
+      "allergyInformation": "No allergens"
+    },
+    {
+      "id": 240875011,
+      "price": "0.64",
+      "title": "Ocado Cucumber",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/240875011/images/image/0/360x360.jpg",
+      "description": "Clean crisp and juicy in a salad or sandwich.",
+      "allergyInformation": "No allergies"
+    },
+    {
+      "id": 227255011,
+      "price": "4.45",
+      "title": "Ocado Fairtrade Ripen at Home Bananas",
+      "imageUrl": "https://mobile.ocado.com/webservices/catalogue/items/item/227255011/images/image/0/360x360.jpg",
+      "description": "Ocado Fairtrade Ripen at Home Bananas.\n\nBananas: Fairtrade certified and sourced from Fairtrade producers.",
+      "allergyInformation": "Factory also handles: Nuts, Peanuts, Sesame Seeds, Milk, Eggs"
+    }
+  ]
+}


### PR DESCRIPTION
Spain's government has blocked at ISP level the access to the raw.github.com subdomain, making impossible for candidates from Spain to reach our fake endpoints, this change will allow to us a proxy service that will point to our package and generate the API, solving our limitations. 

Credit to e.degregorio@ocado.com